### PR TITLE
Explain that "Depends on D" syntax needs blank line of separation

### DIFF
--- a/phabricator-user.rst
+++ b/phabricator-user.rst
@@ -305,7 +305,8 @@ shows the current stack of revisions:
 
 You can also add ``Depends on D<revision ID>`` to the child's commit
 message, replacing ``<revision ID>`` with the ID of the parent
-revision.  The relationship will be created when ``arc diff`` is run.
+revision. (This needs to be its own paragraph, separated by a blank line.)
+The relationship will be created when ``arc diff`` is run.
 
 Unfortunately there is not currently a way to see a combined diff of
 all the stacked commits together without applying the commits


### PR DESCRIPTION
From my testing, and from discussion in `#phabricator` on irc.m.o, it seems that the "Depends on D123" syntax needs to be separated by a blank line, or else it won't be parsed & interpreted correctly.

Let's document that requirement.