### PR TITLE
Annotate some code-blocks

### DIFF
--- a/mozphab-linux.rst
+++ b/mozphab-linux.rst
@@ -47,9 +47,13 @@ Install MozPhab
    for current session. Add it to your profile file (``~/.bashrc`` or equivalent)
    to keep the ``$PATH`` changed ::
 
-   export PATH=~/.local/bin:$PATH
+.. code-block:: bash
+
+   $ export PATH=~/.local/bin:$PATH
 
 3. Ensure running ``arc`` and ``moz-phab`` both work::
+
+.. code-block:: bash
 
    $ moz-phab arc -h
    $ moz-phab -h


### PR DESCRIPTION
In particular, the `export PATH` command is just shown as normal text right now on https://moz-conduit.readthedocs.io/en/latest/mozphab-linux.html .

To fix this, I'm cargo-culting this code-block annotation from elsewhere in this .rst file (and adding an initial "$" for consistency), and I'm hoping it works to fix the formatting of this code.  (I'm adding the annotation for the final code-block, too, even though it's already displayed correctly. I'm assuming it's still good to annotate it for consistency/robustness.)