### PR TITLE
Command of 'submitting change to differential' is added for user who have installed arcanist through MozPhab

### DIFF
--- a/arcanist-user.rst
+++ b/arcanist-user.rst
@@ -53,6 +53,11 @@ Then create a revision in Differential::
 
     $ arc diff
 
+If arcanist is installed through MozPhab::
+
+    $ moz-phab arc diff
+
+
 You'll be taken to an editor to add extra details.  Here is an example
 of input to ``arc diff`` from a real revision
 (https://phabricator.services.mozilla.com/D1298):
@@ -153,6 +158,11 @@ Here's an example that adds another line to our test file from above::
 Submitting the change to Differential is the same command::
 
     $ arc diff
+
+If arcanist is installed through MozPhab::
+
+    $ moz-phab arc diff
+
 
 Your editor will again be opened, but this time the format is much
 simpler.  You just need to provide a change summary, which again is


### PR DESCRIPTION
For the first timers , that are using MozPhab, and have setup Arcanist using MozPhab, the command starting from just ```arc``` won't work and will give an error ```command not found``` so to run the ```arc``` command you have to write ```moz-phab arc```