### PR TITLE
Upgrade: Ensure the old binary is removed first

### DIFF
--- a/mozphab-windows.rst
+++ b/mozphab-windows.rst
@@ -51,7 +51,6 @@ Upgrading a previous non-pip install of moz-phab to use pip
 
 #. Run ``pip3 install MozPhab``.
 
-#. You may need to restart your shell for your changes to take effect. You can check using ``moz-phab version`` - if it works, you've successfully switched to ``moz-phab`` using ``pip``.
+#. Ensure that your non-pip install of ``moz-phab`` is removed or renamed
 
-#. At this point, you should be all set up. If you have already installed ``moz-phab``
-   without using ``pip``, you should remove the file.
+#. You may need to restart your shell for your changes to take effect. You can check using ``moz-phab version`` - if it works, you've successfully switched to ``moz-phab`` using ``pip``.


### PR DESCRIPTION
Feel free to change the wording, but in my case, I had moz-phab installed to C:\mozilla-build\bin and this took priority over pip3 modules and chances are that pip modules in general have a much lower priority than any other place, unless the user specifically added the moz-phab installation ot the path as the last element.

This way now it doesn't depend on any PATH load order.