### PR TITLE
Reorder steps for installing MozPhab on Windows

### DIFF
--- a/mozphab-windows.rst
+++ b/mozphab-windows.rst
@@ -17,12 +17,10 @@ the ``C:\mozilla-build\start-shell.bat``.
    -> Apps -> App & features. It is available at
    https://support.microsoft.com/en-ca/help/2977003/the-latest-supported-visual-c-downloads
    (vc_redist.x64.exe).
-#. Add ``moz-phab``, ``php``, and ``git`` to the ``$PATH`` variable.
-   If you use MSYS (including MozillaBuild) exclusively, you can add this to
-   ``~/.bash_profile``::
-
-     export PATH=$PATH:/c/PHP/:/c/Program\ Files/Git/bin:/c/mozilla-build/Python3/Scripts
-
+#. If you don't have Git already installed (note that it is not
+   currently packaged with MozillaBuild), you'll need to grab it from
+   https://git-scm.com/download/win and install it.
+#. Run ``pip3 install MozPhab``.
 #. Install PHP. The latest should work, e.g. PHP 7.2, VC15 x64 Non
    Thread Safe, from https://windows.php.net/download/. Download the
    Zip. Unzip it somewhere; the following instructions presume ``C:\PHP``.
@@ -31,13 +29,14 @@ the ``C:\mozilla-build\start-shell.bat``.
    before ``;extension=php_curl.dll``. In PHP 7.2, this line is
    just ``;extension=curl``. Then find the line ``;extension_dir =
    "ext"`` and change it to ``extension_dir = "C:\PHP\ext"``.
+#. Add ``moz-phab``, ``php``, and ``git`` to the ``$PATH`` variable.
+   If you use MSYS (including MozillaBuild) exclusively, you can add this to
+   ``~/.bash_profile``::
+
+     export PATH=$PATH:/c/PHP/:/c/Program\ Files/Git/bin:/c/mozilla-build/Python3/Scripts
+     
 #. Run ``php -i`` to verify that it is working. You should see
    "curl" listed in the Configuration section.
-#. If you don't have Git already installed (note that it is not
-   currently packaged with MozillaBuild), you'll need to grab it from
-   https://git-scm.com/download/win and install it. 
-   
-#. Run ``pip3 install MozPhab``. 
 
 #. Ensure running ``arc`` and ``moz-phab`` both work::
 


### PR DESCRIPTION
Reorder steps so programs are installed prior to adding them to path. Installing git and moz-phab are moved before php since they're less involved and they needed for updating path step. The php -i sanity check is left after the path is updated to ensure php is on the path when running the command.