### PR TITLE
Bug 1697203: Move "Mozilla Phab Emails" to standalone section

### DIFF
--- a/phabricator-user.rst
+++ b/phabricator-user.rst
@@ -358,8 +358,9 @@ We will, however, display some revision metadata in associated
 bugs; see `bug 1489706
 <https://bugzilla.mozilla.org/show_bug.cgi?id=1489706>`_.
 
+**************************
 Mozilla Phabricator Emails
-==========================
+**************************
 
 .. image:: images/phab-email-new.png
    :align: center


### PR DESCRIPTION
It isn't part of "BMO Integration", so it shouldn't be
its subheading.

There doesn't seem to be a more appropriate parent heading, and
the section is temporary, so a top-level section makes sense.