### PR TITLE
Update mozphab-macos.rst

### DIFF
--- a/mozphab-macos.rst
+++ b/mozphab-macos.rst
@@ -4,7 +4,11 @@ macOS MozPhab Installation Guide
 
 MozPhab can be installed from PyPI
 
-This requires Git, Rust, and Python 3.6 or higher with `pip`.
+This requires Git and Python 3.6 or higher with `pip`.
+
+.. note::
+
+    There isn't a `moz-phab` wheel for all macOS systems, so you may need to install Rust so that `pip` can build `moz-phab` itself.
 
 Install Python3 using Homebrew
 ------------------------------

--- a/mozphab-macos.rst
+++ b/mozphab-macos.rst
@@ -4,7 +4,7 @@ macOS MozPhab Installation Guide
 
 MozPhab can be installed from PyPI
 
-This requires Git and Python 3.6 or higher with `pip`.
+This requires Git, Rust, and Python 3.6 or higher with `pip`.
 
 Install Python3 using Homebrew
 ------------------------------


### PR DESCRIPTION
Added mention of Rust that is a prerequisite for successful MozPhab installation on recent macOS systems (both 11.5 and 12.2.1 did require to install it separately to proceed).