### PR TITLE
Update mozphab-macos.rst

### DIFF
--- a/mozphab-macos.rst
+++ b/mozphab-macos.rst
@@ -8,7 +8,7 @@ This requires Git and Python 3.6 or higher with `pip`.
 
 .. note::
 
-    There isn't a `moz-phab` wheel for all macOS systems, so you may need to install Rust so that `pip` can build `moz-phab` itself.
+    There isn't a `moz-phab` wheel for all macOS systems, so you may need to install Rust so that `pip` can build `moz-phab` itself. Users of Mac computers with Apple silicon may need to ensure that Python version 3.9.1 or newer is installed to run `moz-phab` scripts with Python natively.
 
 Install Python3 using Homebrew
 ------------------------------


### PR DESCRIPTION
Added a mention of the earliest Python version that is able to support MacBooks with M1 chipsets for using `moz-phab` as bootstrapping is not recommended with Rosetta 2.

Any Python version earlier than 3.9.1 will run via emulator by default as the [native binaries were not yet supported until 3.9.1](https://www.python.org/downloads/release/python-391/). Bootstrapping with Rosetta used to kill the process ([see Bug 1704126](https://bugzilla.mozilla.org/show_bug.cgi?id=1704126)), so the OS check for M1 was added to fail development on the emulator.